### PR TITLE
Allow to create event channels without default values

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/no-unused-vars": 2,
     "curly": 2,
+    "quotes": [2, "single"],
     "eqeqeq": 2,
     "no-throw-literal": 2,
     "semi": 0

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -7,7 +7,7 @@ export default abstract class BaseChannel<U, T> {
 
     constructor (
         private _namespace: string,
-        private _defaultValue: Required<T>,
+        private _defaultValue?: Required<T>,
     ) {}
 
     public registerPromise (providers: U[]): Promise<Bus<T>> {
@@ -17,10 +17,10 @@ export default abstract class BaseChannel<U, T> {
     }
 
     protected _initiateBus (providers: Provider[]) {
-        return new Bus<T>(this._namespace, this._defaultValue, providers);
+        return new Bus<T>(this._namespace, providers, this._defaultValue || {} as T);
     }
 
     protected _initiateClient (provider: Provider) {
-        return new Client<T>(this._namespace, this._defaultValue, [provider]);
+        return new Client<T>(this._namespace, [provider], this._defaultValue || {} as T);
     }
 }

--- a/src/iframes.ts
+++ b/src/iframes.ts
@@ -13,7 +13,7 @@ export default class IFrameChannel<T> extends BaseChannel<HTMLIFrameElement, T> 
 
     constructor (
         namespace: string,
-        defaultValue: Required<T>,
+        defaultValue?: Required<T>,
         /**
          * for testing purposes
          */

--- a/src/tangle.ts
+++ b/src/tangle.ts
@@ -28,8 +28,8 @@ export class Client<T> {
 
     constructor(
         public readonly namespace: string,
-        public readonly defaultValue: T,
         public readonly providers: Provider[],
+        public readonly defaultValue: T,
         private readonly _isBus: boolean = false
     ) {
         this._outbound = new Subject<Payload<T>>();
@@ -231,7 +231,7 @@ export class Client<T> {
                         return { transient: { ...transient, ...event.transient } };
                     }
 
-                    throw new Error(`Neither event nor state change was given`);
+                    throw new Error('Neither event nor state change was given');
                 }),
                 map((combo) => {
                     if (this._isBus) {
@@ -278,8 +278,8 @@ export class Client<T> {
 }
 
 export class Bus<T> extends Client<T> {
-    constructor(namespace: string, defaultValue: T, providers: Provider[]) {
-        super(namespace, defaultValue, providers, true);
+    constructor(namespace: string, providers: Provider[], defaultValue: T) {
+        super(namespace, providers, defaultValue, true);
     }
 }
 

--- a/test-d/type.test.ts
+++ b/test-d/type.test.ts
@@ -1,22 +1,32 @@
 import { expectType } from 'tsd';
 import { Observable } from 'rxjs';
 import { Bus, Payload as PkgPayload } from '../src/tangle';
+import IFrameChannel from '../src/iframes';
+import WorkerThreadChannel from '../src/worker_threads';
 
 type Payload = {
     foo: string
     bar: number
 };
+const defaultPayload = { foo: '', bar: 123 };
 
 const bus = new Bus<Payload>(
     'namespace',
+    [],
     {
         foo: '',
         bar: 123,
         // @ts-expect-error not part of state
         loo: true
-    },
-    []
+    }
 );
+
+new WorkerThreadChannel<Payload>('namespace');
+new WorkerThreadChannel<Payload>('namespace', defaultPayload);
+new IFrameChannel<Payload>('namespace');
+new IFrameChannel<Payload>('namespace', defaultPayload);
+// @ts-expect-error missing property
+new IFrameChannel<Payload>('namespace', { foo: '' });
 
 bus.listen('foo', (param) => {
     expectType<string>(param);

--- a/test/iframes.test.ts
+++ b/test/iframes.test.ts
@@ -11,12 +11,12 @@ const defaultValue = { someProp: 8 };
 
 test('should allow communication between multiple worker threads', async (t) => {
     const resourceLoader = new ResourceLoader({
-        proxy: "http://127.0.0.1:8080",
+        proxy: 'http://127.0.0.1:8080',
         strictSSL: false
     });
     const virtualConsole = new VirtualConsole();
     virtualConsole.sendTo(console);
-    const dom = new JSDOM(``, {
+    const dom = new JSDOM('', {
         runScripts: 'outside-only',
         resources: resourceLoader,
         virtualConsole

--- a/test/tangle.test.ts
+++ b/test/tangle.test.ts
@@ -3,34 +3,27 @@ import { Observable } from 'rxjs';
 
 import { Bus } from '../src/tangle';
 
-const sym1 = Symbol('');
 interface Payload {
     foo: number
     bar: number
     [key: number | symbol]: number
 }
 
-const defaultPayload: Payload = {
-    foo: 0,
-    bar: 0,
-    [sym1]: 0
-};
-
 tap.test('has a transient getter', (t) => {
-    const bus = new Bus<Payload>("testing", defaultPayload, []);
+    const bus = new Bus<Payload>('testing', [], {} as Payload);
     t.ok(bus.transient instanceof Observable);
     t.end();
 });
 
 tap.test('allows to get state value', (t) => {
-    const bus = new Bus<Payload>("testing", defaultPayload, []);
+    const bus = new Bus<Payload>('testing', [], { foo: 0, bar: 0 } as Payload);
     t.matchSnapshot(bus.state);
     t.end();
 });
 
 tap.test('has a list if event names', (t) => {
     const noop = () => { /** */ };
-    const bus = new Bus<Payload>("testing", defaultPayload, []);
+    const bus = new Bus<Payload>('testing', [], {} as Payload);
     bus.on('foo', noop);
     bus.on('bar', noop);
 
@@ -42,7 +35,7 @@ tap.test('has a list if event names', (t) => {
 
 tap.test('allows to get listener count', (t) => {
     const noop = () => { /** */ };
-    const bus = new Bus<Payload>("testing", defaultPayload, []);
+    const bus = new Bus<Payload>('testing', [], {} as Payload);
     bus.on('foo', noop);
     bus.on('foo', noop);
     bus.on('foo', noop);
@@ -61,7 +54,7 @@ tap.test('allows to get listener count', (t) => {
 
 tap.test('allows to get listeners of certain event', (t) => {
     const noop = () => { /** */ };
-    const bus = new Bus<Payload>("testing", defaultPayload, []);
+    const bus = new Bus<Payload>('testing', [], {} as Payload);
     bus.on('foo', noop);
     const fn = bus.listeners('foo')[0];
 

--- a/test/worker_threads.test.ts
+++ b/test/worker_threads.test.ts
@@ -108,7 +108,7 @@ test('should allow to send events', async (t) => {
 test('should allow to listen once', async (t) => {
     const namespace = 'test4';
 
-    const ch = new Channel<any>(namespace, defaultValue);
+    const ch = new Channel<any>(namespace);
     const bus = await ch.registerPromise([
         new Worker(workerOncePath, { argv, workerData: { channel: namespace } }),
     ]);
@@ -128,7 +128,7 @@ test('should allow to listen once', async (t) => {
 test('should allow to unsubscribe via off', async (t) => {
     const namespace = 'test5';
 
-    const ch = new Channel<any>(namespace, defaultValue);
+    const ch = new Channel<any>(namespace);
     const bus = await ch.registerPromise([
         new Worker(workerOffPath, { argv, workerData: { channel: namespace } }),
     ]);
@@ -148,7 +148,7 @@ test('should allow to unsubscribe via off', async (t) => {
 test('should allow to unsubscribe via unsubscribe', async (t) => {
     const namespace = 'test5';
 
-    const ch = new Channel<any>(namespace, defaultValue);
+    const ch = new Channel<any>(namespace);
     const bus = await ch.registerPromise([
         new Worker(workerUnsubscribePath, { argv, workerData: { channel: namespace } }),
     ]);
@@ -168,7 +168,7 @@ test('should allow to unsubscribe via unsubscribe', async (t) => {
 test('should allow to unsubscribe', async (t) => {
     const namespace = 'test6';
 
-    const ch = new Channel<any>(namespace, defaultValue);
+    const ch = new Channel<any>(namespace);
     const bus = await ch.registerPromise([
         new Worker(workerRemoveAllListenerPath, { argv, workerData: { channel: namespace } }),
     ]);


### PR DESCRIPTION
If you want to just send around events, there is no state default value needed.