### PR TITLE
Worker threads don't care but json.stringify will skip ES6 maps

### DIFF
--- a/src/tangle.ts
+++ b/src/tangle.ts
@@ -81,7 +81,9 @@ export class Client<T> {
             filter(Boolean),
             scan((acc, curr) => {
                 if (typeof curr?.clients?.forEach === 'function') {
-                    curr.clients.forEach(((value, key) => acc.clients.set(key, value)));
+                    // deserialize json into es6 map
+                    const _curr: Context = { clients: new Map(curr.clients) };
+                    _curr.clients.forEach(((value, key) => acc.clients.set(key, value)));
                 }
                 return acc;
             }, this._context),
@@ -305,7 +307,9 @@ export class Client<T> {
             .subscribe();
 
         if (!this._isBus) {
-            this._notifer.pipe(map(context => {
+            this._notifer.pipe(map(_context => {
+                // es6 map is not json serializable
+                const context = { clients: Array.from(_context.clients.entries()) };
                 return { context } as any; // special payload
             })).subscribe(payload => {
                 this.providers.forEach((provider) => {

--- a/src/tangle.ts
+++ b/src/tangle.ts
@@ -80,8 +80,8 @@ export class Client<T> {
             pluck('context'),
             filter(Boolean),
             scan((acc, curr) => {
-                if (typeof curr?.clients?.forEach === 'function') {
-                    // deserialize json into es6 map
+                if (Array.isArray(curr?.clients)) {
+                    // deserialize array into es6 map
                     const _curr: Context = { clients: new Map(curr.clients) };
                     _curr.clients.forEach(((value, key) => acc.clients.set(key, value)));
                 }


### PR DESCRIPTION
While we haven't use the `Context` type anywhere in `whenReady` and `context` subscribers `on/postMessage` in most implementations will skip ES6 maps which is why it won't include client's entries.

The fix here will provide special treatment for ES6 maps.

PS: Slipped my attention since the test cases rely on worker thread impl that happily passes es6 maps around.